### PR TITLE
Exile command

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,0 +1,16 @@
+<factorypath>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/milkbowl/vault/VaultAPI/1.6/VaultAPI-1.6.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/bukkit/bukkit/1.9-R0.1-SNAPSHOT/bukkit-1.9-R0.1-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/avaje/ebean/2.8.1/ebean-2.8.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/javax/persistence/persistence-api/1.0/persistence-api-1.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/spigotmc/spigot-api/1.12.2-R0.1-SNAPSHOT/spigot-api-1.12.2-R0.1-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/commons-lang/commons-lang/2.6/commons-lang-2.6.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/junit/junit/4.10/junit-4.10.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/guava/guava/21.0/guava-21.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/google/code/gson/gson/2.8.0/gson-2.8.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/yaml/snakeyaml/1.19/snakeyaml-1.19.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/net/md-5/bungeecord-chat/1.12-SNAPSHOT/bungeecord-chat-1.12-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/projectlombok/lombok/1.16.22/lombok-1.16.22.jar" enabled="true" runInBatchMode="false"/>
+</factorypath>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.Alvaeron</groupId>
 	<artifactId>RPEngine</artifactId>
-	<version>4.5.4</version>
+	<version>4.5.6</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/main/java/com/Alvaeron/Engine.java
+++ b/src/main/java/com/Alvaeron/Engine.java
@@ -8,6 +8,8 @@ import java.io.OutputStream;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -17,6 +19,7 @@ import com.Alvaeron.commands.BirdCommand;
 import com.Alvaeron.commands.CardCommand;
 import com.Alvaeron.commands.ChatCommands;
 import com.Alvaeron.commands.CountdownCommand;
+import com.Alvaeron.commands.ExileCommand;
 import com.Alvaeron.commands.RPEngineCommand;
 import com.Alvaeron.commands.RollCommand;
 import com.Alvaeron.commands.SpawnPointCommand;
@@ -78,7 +81,8 @@ public class Engine extends JavaPlugin {
 			mm.createRoleplayPlayer(pl);
 		}
 		checkSoftDependencies();
-
+		
+		loadVars();
 		loadLang();
 	}
 
@@ -90,6 +94,7 @@ public class Engine extends JavaPlugin {
 		getCommand("rpengine").setExecutor(new RPEngineCommand(this));
 		getCommand("spawnpoint").setExecutor(new SpawnPointCommand(this));
 		getCommand("exile").setExecutor(new ExileCommand(this));
+		getCommand("exile").setTabCompleter(new ExileCommand(this));
 		ChatCommands ch = new ChatCommands(this);
 		getCommand("whisper").setExecutor(ch);
 		getCommand("shout").setExecutor(ch);
@@ -121,7 +126,17 @@ public class Engine extends JavaPlugin {
 		perms = rsp.getProvider();
 		return perms != null;
 	}
+	public void loadVars() {
+		ConfigurationSection location = this.getConfig().getConfigurationSection("exile");
+		Double x = location.getDouble("x");
+		Double y = location.getDouble("y");
+		Double z = location.getDouble("z"); 
+		String world = location.getString("world");
 
+		Location l = new Location(Bukkit.getWorld(world), x, y, z);
+		
+		manager.exileLocation = l;		
+	}
 	/**
 	 * Load the lang.yml file.
 	 */

--- a/src/main/java/com/Alvaeron/Engine.java
+++ b/src/main/java/com/Alvaeron/Engine.java
@@ -89,6 +89,7 @@ public class Engine extends JavaPlugin {
 		getCommand("countdown").setExecutor(new CountdownCommand(this));
 		getCommand("rpengine").setExecutor(new RPEngineCommand(this));
 		getCommand("spawnpoint").setExecutor(new SpawnPointCommand(this));
+		getCommand("exile").setExecutor(new ExileCommand(this));
 		ChatCommands ch = new ChatCommands(this);
 		getCommand("whisper").setExecutor(ch);
 		getCommand("shout").setExecutor(ch);

--- a/src/main/java/com/Alvaeron/commands/AbstractCommand.java
+++ b/src/main/java/com/Alvaeron/commands/AbstractCommand.java
@@ -1,18 +1,20 @@
 package com.Alvaeron.commands;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 import com.Alvaeron.Engine;
 import com.Alvaeron.player.RoleplayPlayer;
 
-public abstract class AbstractCommand implements CommandExecutor {
+public abstract class AbstractCommand implements CommandExecutor, TabCompleter {
 	protected Engine plugin;
 	private Senders[] definedSenders;
 	protected Player player;
@@ -44,6 +46,11 @@ public abstract class AbstractCommand implements CommandExecutor {
 	 *            - the arguments
 	 * @return did this command succeed?
 	 */
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args){
+		return null;
+	}
+	
 	public abstract boolean handleCommand(CommandSender sender, Command cmd, String Commandlabel,
 			String[] args);
 

--- a/src/main/java/com/Alvaeron/commands/ExileCommand.java
+++ b/src/main/java/com/Alvaeron/commands/ExileCommand.java
@@ -1,0 +1,57 @@
+package com.Alvaeron.commands;
+
+import java.util.Random;
+
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Alvaeron.Engine;
+import com.Alvaeron.utils.Lang;
+
+public class ExileCommand extends AbstractCommand {
+
+	public ExileCommand(Engine plugin) {
+		super(plugin, Senders.values());
+	}
+
+    @Override
+	public boolean handleCommand(CommandSender sender, Command cmd, String Commandlabel,
+    String[] args) {
+        if (args[0].toLowerCase() == 'approve' && args.length < 2)
+            if(player.hasPermission('rpengine.exile.approve')){
+                final RoleplayPlayer targetPlayer = Engine.manager.exileQueue.poll();
+
+                if (targetPlayer ==  null)
+                {
+                    player.sendMessage(Lang.EXILE_APPROVAL.toString()
+                    .replace("%n", targetPlayer.getName())
+                }
+                else
+                {
+                    player.sendMessage(Lang.EXILE_EMPTY.toString()
+                    .replace("%n", targetPlayer.getName())
+                }
+            }
+        else{
+            if(player.hasPermission('rpengine.exile.set')){
+                if (player.getServer().getPlayer(args[0]) != null) {
+                    if (player.getWorld() == plugin.getServer().getPlayer(args[0]).getWorld()) { // Makes sure they are in the same world
+                        final RoleplayPlayer targetPlayer = Engine.manager.getPlayer(player.getServer().getPlayer(args[0]).getUniqueId()); //gets the target player to be exiled
+                        final String reason = ''
+                        if (args.length < 2)
+                            reason = "No Specific Reason"
+                        else 
+                            reason = args[1];
+
+                        Engine.manager.exileQueue.offer(targetPlayer);
+                        plugin.getServer().broadcastMessage(Lang.EXILE_USAGE.toString()
+                                .replace("%n", targetPlayer.getName())
+                                .replace("%r", reason)
+                    } 
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/Alvaeron/commands/ExileCommand.java
+++ b/src/main/java/com/Alvaeron/commands/ExileCommand.java
@@ -1,13 +1,22 @@
 package com.Alvaeron.commands;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 
 import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
 import com.Alvaeron.Engine;
+import com.Alvaeron.player.ExilePlayer;
+import com.Alvaeron.player.RoleplayPlayer;
 import com.Alvaeron.utils.Lang;
 
 public class ExileCommand extends AbstractCommand {
@@ -19,39 +28,208 @@ public class ExileCommand extends AbstractCommand {
     @Override
 	public boolean handleCommand(CommandSender sender, Command cmd, String Commandlabel,
     String[] args) {
-        if (args[0].toLowerCase() == 'approve' && args.length < 2)
-            if(player.hasPermission('rpengine.exile.approve')){
-                final RoleplayPlayer targetPlayer = Engine.manager.exileQueue.poll();
+    	
+		final Player player = (Player) sender;
 
-                if (targetPlayer ==  null)
+    	
+    	if (args[0].equalsIgnoreCase("location"))
+    	{
+    		if(player.hasPermission("rpengine.exile.set")){
+    			
+    			StringBuilder sb = new StringBuilder();
+    			sb.append("The current exile location is at: ");
+    			sb.append(Engine.manager.exileLocation.getX()).append(", ");
+    			sb.append(Engine.manager.exileLocation.getY()).append(", ");
+    			sb.append(Engine.manager.exileLocation.getZ()).append(", ");
+    			player.sendMessage(sb.toString());
+    		}
+    		else {
+    			player.sendMessage("You do not have permission to do that.");
+    		}
+    	}
+    	if (args[0].equalsIgnoreCase("set")) {
+    		if(player.hasPermission("rpengine.exile.approve")){
+    			
+    			if (args.length >= 4) {    			
+	    			plugin.getConfig().set("exile.x", Double.valueOf(args[1]));
+	    			plugin.getConfig().set("exile.y", Double.valueOf(args[2]));
+	    			plugin.getConfig().set("exile.z", Double.valueOf(args[3]));
+	    			if (args.length >= 5) {
+	    				plugin.getConfig().set("exile.world", String.valueOf(args[4]));
+	    			}
+    			
+	    			plugin.saveConfig();
+	    			
+	    			ConfigurationSection location = plugin.getConfig().getConfigurationSection("exile");
+	    			Double x = location.getDouble("x");
+	    			Double y = location.getDouble("y");
+	    			Double z = location.getDouble("z"); 
+	    			String world = location.getString("world");
+	    			
+	    			Location l = new Location(Bukkit.getWorld(world), x, y, z);
+	    			
+	    			Engine.manager.exileLocation = l;	
+	    			
+	    			StringBuilder sb = new StringBuilder();
+	    			sb.append("Exile location updated to: ");
+	    			sb.append(Engine.manager.exileLocation.getX()).append(", ");
+	    			sb.append(Engine.manager.exileLocation.getY()).append(", ");
+	    			sb.append(Engine.manager.exileLocation.getZ()).append(", ");
+	    			player.sendMessage(sb.toString());
+    			}
+    			else
+    			{
+    				player.sendMessage("You must have an x, y, and z coordinate. Format like /exile set x y z.");
+    			}
+    			
+    		}
+    		else {
+    			player.sendMessage("You do not have permission to do that.");
+    		}
+    	}
+        if (args[0].equalsIgnoreCase("approve") && args.length < 2) {
+            if(player.hasPermission("rpengine.exile.approve")){
+                final ExilePlayer targetPlayer = Engine.manager.exileQueue.poll();
+                                
+                if (targetPlayer !=  null)
                 {
-                    player.sendMessage(Lang.EXILE_APPROVAL.toString()
-                    .replace("%n", targetPlayer.getName())
+                	targetPlayer.player.getPlayer().teleport(Engine.manager.exileLocation);
+                	plugin.getServer().broadcastMessage(Lang.EXILE_APPROVE.toString()
+                    .replace("%n", targetPlayer.player.getName()));
                 }
                 else
                 {
-                    player.sendMessage(Lang.EXILE_EMPTY.toString()
-                    .replace("%n", targetPlayer.getName())
+                	plugin.getServer().broadcastMessage(Lang.EXILE_EMPTY.toString());
                 }
             }
-        else{
-            if(player.hasPermission('rpengine.exile.set')){
-                if (player.getServer().getPlayer(args[0]) != null) {
-                    if (player.getWorld() == plugin.getServer().getPlayer(args[0]).getWorld()) { // Makes sure they are in the same world
-                        final RoleplayPlayer targetPlayer = Engine.manager.getPlayer(player.getServer().getPlayer(args[0]).getUniqueId()); //gets the target player to be exiled
-                        final String reason = ''
-                        if (args.length < 2)
-                            reason = "No Specific Reason"
-                        else 
-                            reason = args[1];
-
-                        Engine.manager.exileQueue.offer(targetPlayer);
-                        plugin.getServer().broadcastMessage(Lang.EXILE_USAGE.toString()
-                                .replace("%n", targetPlayer.getName())
-                                .replace("%r", reason)
-                    } 
-                }
+            else {
+            	player.sendMessage("You do not have permission to do that.");
             }
         }
+        if (args[0].equalsIgnoreCase("deny") && args.length < 2) {
+            if(player.hasPermission("rpengine.exile.approve")){
+                final ExilePlayer targetPlayer = Engine.manager.exileQueue.poll();
+                                
+                if (targetPlayer !=  null)
+                {
+                	plugin.getServer().broadcastMessage(Lang.EXILE_DENY.toString()
+                    .replace("%n", targetPlayer.player.getName()));
+                }
+                else
+                {
+                	plugin.getServer().broadcastMessage(Lang.EXILE_EMPTY.toString());
+                }
+            }
+            else {
+            	player.sendMessage("You do not have permission to do that.");
+            }
+        }
+        if (args[0].equalsIgnoreCase("next") && args.length < 2) {
+        	 if(player.hasPermission("rpengine.exile.set")){
+        		 final ExilePlayer targetPlayer = Engine.manager.exileQueue.peek();
+                                  
+                 if (targetPlayer !=  null)
+                 {
+                 	plugin.getServer().broadcastMessage(Lang.EXILE_NEXT.toString()
+                     .replace("%n", targetPlayer.player.getName())
+                     .replace("%r", targetPlayer.reason));
+                 }
+                 else
+                 {
+                 	plugin.getServer().broadcastMessage(Lang.EXILE_EMPTY.toString());
+                 }
+        	 }
+        	 else {
+        		 player.sendMessage("You do not have permission to do that.");
+        	 }
+        }
+        else{
+        	if (args[0].equalsIgnoreCase("player")){
+	            if(player.hasPermission("rpengine.exile.set")){
+	                if (player.getServer().getPlayer(args[1]) != null) {
+	                    if (player.getWorld() == plugin.getServer().getPlayer(args[1]).getWorld()) { // Makes sure they are in the same world
+	                        final RoleplayPlayer targetPlayer = Engine.manager.getPlayer(player.getServer().getPlayer(args[1]).getUniqueId()); //gets the target player to be exiled
+	                        
+
+	                        if (Engine.manager.exileQueue.stream().filter(x -> x.player == targetPlayer).count() > 0)
+	                        {
+	                        	player.sendMessage("Player is already in queue for exile.");
+	                        }
+	                        else 
+	                        {	                        
+		                        StringBuilder reason = new StringBuilder();
+		                        
+		                        if (args.length == 2)
+		                        {
+		                            reason.append("No Specific Reason");
+		                        }
+		                        else
+		                        {
+		                        	for (int i = 2; i < args.length; i++) {
+		                        		reason.append(args[i]);
+		                        		
+		                        		if (i < args.length -1 ) {
+		                        			reason.append(" ");
+		                        		}
+		    						}	
+		                        }
+		                        
+		                        Engine.manager.exileQueue.offer(new ExilePlayer(targetPlayer, reason.toString()));
+		                        plugin.getServer().broadcastMessage(Lang.EXILE_USAGE.toString()
+		                                .replace("%n", targetPlayer.getName())
+		                                .replace("%r", reason.toString()));
+	                        }
+	                    } 
+	                }
+	            }
+	            else {
+	            	player.sendMessage("You do not have permission to do that.");
+	            }
+	        }
+        }
+        return true;
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+
+        if (command.getName().equalsIgnoreCase("exile")) {
+
+            List<String> mainArguments = Arrays.asList("player", "approve", "deny", "next", "set", "location");
+            List<String> finalList = new ArrayList<>();
+
+            if (args.length == 1) {
+
+                if (!args[0].equals("")) {
+
+                    for (String string : mainArguments) {
+                       // This only works if the player has already started typing the subcommand
+                        if (string.startsWith(args[0].toLowerCase())) {
+                            finalList.add(string);
+                        }
+                    }
+
+                } else {
+
+                    // This does nothing
+                    finalList = mainArguments;
+
+                }
+
+                Collections.sort(finalList);
+                return finalList;
+            }
+
+            if (args.length == 0) {
+
+                // This also does nothing
+                finalList = mainArguments;
+                Collections.sort(finalList);
+                return finalList;
+
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/Alvaeron/nametags/FakeTeam.java
+++ b/src/main/java/com/Alvaeron/nametags/FakeTeam.java
@@ -3,6 +3,7 @@ package com.Alvaeron.nametags;
 import lombok.Data;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.UUID;
 
 /**
@@ -62,5 +63,21 @@ public class FakeTeam {
         }
         return builder.toString();
     }
+
+	public String getName() {
+		return name;
+	}
+
+	public ArrayList<String> getMembers() {
+		return members;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public String getSuffix() {
+		return suffix;
+	}
 
 }

--- a/src/main/java/com/Alvaeron/nametags/PacketData.java
+++ b/src/main/java/com/Alvaeron/nametags/PacketData.java
@@ -13,8 +13,9 @@ enum PacketData {
     v1_8("g", "c", "d", "a", "h", "i", "b", "NA", "e"),
     v1_9("h", "c", "d", "a", "i", "j", "b", "f", "e"),
     v1_10("h", "c", "d", "a", "i", "j", "b", "f", "e"),
-    v1_11("h", "c", "d", "a", "i", "j", "b", "f", "e"),
-    v1_12("h", "c", "d", "a", "i", "j", "b", "f", "e");
+    v1_11 ("h", "c", "d", "a", "i", "j", "b", "f", "e"),
+    v1_12 ("h", "c", "d", "a", "i", "j", "b", "f", "e");
+
 
     private String members;
     private String prefix;
@@ -25,5 +26,32 @@ enum PacketData {
     private String displayName;
     private String push;
     private String visibility;
+	public String getPrefix() {
+		return prefix;
+	}
+	public String getSuffix() {
+		return suffix;
+	}
+	public String getMembers() {
+		return members;
+	}
+	public String getTeamName() {
+		return teamName;
+	}
+	public String getParamInt() {
+		return paramInt;
+	}
+	public String getPackOption() {
+		return packOption;
+	}
+	public String getDisplayName() {
+		return displayName;
+	}
+	public String getPush() {
+		return push;
+	}
+	public String getVisibility() {
+		return visibility;
+	}
 
 }

--- a/src/main/java/com/Alvaeron/player/ExilePlayer.java
+++ b/src/main/java/com/Alvaeron/player/ExilePlayer.java
@@ -1,0 +1,11 @@
+package com.Alvaeron.player;
+
+public class ExilePlayer{
+	public RoleplayPlayer player;
+	public String reason;
+	
+	public ExilePlayer(RoleplayPlayer player2, String reason2) {
+		player = player2;
+		reason = reason2;
+	}
+}

--- a/src/main/java/com/Alvaeron/player/PlayerManager.java
+++ b/src/main/java/com/Alvaeron/player/PlayerManager.java
@@ -1,8 +1,12 @@
 package com.Alvaeron.player;
 
 import java.util.ArrayList;
+import java.util.Queue;
+import java.util.LinkedList;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +18,8 @@ import com.Alvaeron.Engine;
 public class PlayerManager implements Listener {
 	public Engine plugin;
 	public ArrayList<RoleplayPlayer> players = new ArrayList<RoleplayPlayer>();
-	public Queue<RoleplayPlayer> exileQueue = new Queue<RoleplayPlayer>
+	public Queue<ExilePlayer> exileQueue = new LinkedList<ExilePlayer>();
+	public Location exileLocation;
 	public PlayerManager(Engine plugin) {
 		this.plugin = plugin;
 	}

--- a/src/main/java/com/Alvaeron/player/PlayerManager.java
+++ b/src/main/java/com/Alvaeron/player/PlayerManager.java
@@ -14,7 +14,7 @@ import com.Alvaeron.Engine;
 public class PlayerManager implements Listener {
 	public Engine plugin;
 	public ArrayList<RoleplayPlayer> players = new ArrayList<RoleplayPlayer>();
-
+	public Queue<RoleplayPlayer> exileQueue = new Queue<RoleplayPlayer>
 	public PlayerManager(Engine plugin) {
 		this.plugin = plugin;
 	}

--- a/src/main/java/com/Alvaeron/player/RoleplayPlayer.java
+++ b/src/main/java/com/Alvaeron/player/RoleplayPlayer.java
@@ -112,4 +112,36 @@ public class RoleplayPlayer {
 			return this == Gender.NONE ? "NONE" : Character.toString(this.name().charAt(0)).toUpperCase() + this.name().toLowerCase().substring(1);
 		}
 	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getAge() {
+		return age;
+	}
+
+	public Gender getGender() {
+		return gender;
+	}
+
+	public String getRace() {
+		return race;
+	}
+
+	public String getNation() {
+		return nation;
+	}
+
+	public String getDesc() {
+		return desc;
+	}
+
+	public Channel getChannel() {
+		return channel;
+	}
+
+	public boolean isOOC() {
+		return OOC;
+	}
 }

--- a/src/main/java/com/Alvaeron/utils/Lang.java
+++ b/src/main/java/com/Alvaeron/utils/Lang.java
@@ -78,11 +78,14 @@ public enum Lang {
     CARD_RACE_USAGE("card-race-usage", "&cUsage: &f/card race %r."),
     CARD_NATION_USAGE("card-nation-usage", "&cUsage: &f/card nation %n."),
     CARD_DESC_USAGE("card-desc-usage", "&cUsage: &f/card desc [description]."),
-    CARD_OFFLINE("card-offline", "&cError: &f%p is offline.");
+    CARD_OFFLINE("card-offline", "&cError: &f%p is offline."),
 
-    EXILE_USAGE("exile-usage","%n has been queued for exile for &r.");
-    EXILE_APPROVAL("exile-approval","%n has been approved for exile.");
+    EXILE_USAGE("exile-usage","%n has been queued for exile for %r."),
+    EXILE_APPROVE("exile-approve","%n has been approved for exile."),
+    EXILE_DENY("exile-deny","%n has been denied for exile."),
+    EXILE_NEXT("exile-next","%n is next in queue to be exiled for %r."),
     EXILE_EMPTY("exile-empty","There is nobody in queue for exile.");
+
     private String path;
     private String def;
     private static YamlConfiguration LANG;

--- a/src/main/java/com/Alvaeron/utils/Lang.java
+++ b/src/main/java/com/Alvaeron/utils/Lang.java
@@ -79,7 +79,10 @@ public enum Lang {
     CARD_NATION_USAGE("card-nation-usage", "&cUsage: &f/card nation %n."),
     CARD_DESC_USAGE("card-desc-usage", "&cUsage: &f/card desc [description]."),
     CARD_OFFLINE("card-offline", "&cError: &f%p is offline.");
- 
+
+    EXILE_USAGE("exile-usage","%n has been queued for exile for &r.");
+    EXILE_APPROVAL("exile-approval","%n has been approved for exile.");
+    EXILE_EMPTY("exile-empty","There is nobody in queue for exile.");
     private String path;
     private String def;
     private static YamlConfiguration LANG;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,3 +54,9 @@ playerHealth: 40
 
 # What language messages are sent in
 language: en_us
+
+exile:
+  x: 0
+  y: 0
+  z: 0
+  world: world

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -33,6 +33,8 @@ commands:
   spawnpoint:
     description: Teleport command for nation spawnpoints
     aliases: [nationspawn, rpspawn, nationhome, rphome]
+  exile:
+    description: Queues a player for exile. Use exile approve to approve an exile, and exile next to see the next player queued for exile
 
 permissions:
   #Spawnpoint permissions
@@ -44,7 +46,10 @@ permissions:
     description: Allows teleport to own nations spawnpoint
   rpengine.spawnpoint.others:
     description: Allows teleport to other nations
-
+  rpengine.exile.approve:
+    description: Allows approval for exiling players
+  rpengine.exile.set:
+    description: Allows setting players in queue for exile
   #Chat perms
   rpengine.chat.color:
     description: Allows you to use colors in the chat


### PR DESCRIPTION
Added the Exile Command, which has the following sub commands:
- player - Adds a player to the queue for exile. Followed by the player name and an optional reason. ( a default reason is provided if none is entered)
- approve - Approves the next player on the queue for exile and sends them to the set location.
- deny - Denies the next player on the queue for exile and removes them from the queue.
- next - Views the next player on the queue for exile, and the reason why.
- set - Sets the location of the exile tp. Followed by X Y Z and an optional world. (defaults to the currently set world for exile location)
- location - Views the location of the exile tp.

Additionally adds:
- The loadVars function to get the needed exile location values from the config.
- The TabCompleter interface to the AbstractCommand so I can auto complete the subcommands.
- The ExilePlayer class to hold the player and reason for exile in the ExileQueue (set up in the PlayerManager)
- 2 permissions:
    - rpengine.exile.approve: allows for approving exiles and setting exile location
    - rpengine.exile.set: allows for adding exiles to queue for approval.
- Several additional that were needed to get the project to build for me. These can be removed if needed, as I think I can get it to work now without them.